### PR TITLE
chore: rm useVueTemplateBabelCompiler.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "author": "JuniorTour",
   "license": "MIT",
   "files": [
-    "lib/index.js",
-    "useVueTemplateBabelCompiler.sh"
+    "lib/index.js"
   ],
   "engines": {
     "node": ">=12.0.0"

--- a/useVueTemplateBabelCompiler.sh
+++ b/useVueTemplateBabelCompiler.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-mv node_modules/vue-template-es2015-compiler node_modules/vue-template-es2015-compiler-deprecated
-mv node_modules/vue-template-babel-compiler node_modules/vue-template-es2015-compiler
-echo 'Use vue-template-babel-compiler Success!'


### PR DESCRIPTION
Since [replace vue-template-es2015-compiler is NOT a standard usage, without official API support](https://github.com/JuniorTour/vue-template-babel-compiler/blob/main/doc/Usage.md#2-only-substitute-vue-template-es2015-compiler), we will not recommend this.

But this feature is our initial purpose, so we will only remove the shell script and keep the `transpile()` itself.
 