### PR TITLE
fix: Identifier in computed OptionalMemberExpression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function shouldPrependVm(path) {
   ((_scope$path = scope.path) === null || _scope$path === void 0 ? void 0 : _scope$path.listKey) !== 'params' // not a id of a Declaration:
   && !(t$1.isVariableDeclarator(parent) && parent.id === node) // not a param of a function
   && !(t$1.isFunctionExpression(parent) && parent.params.indexOf(node) > -1) // not a property of OptionalMemberExpression
-  && !(t$1.isOptionalMemberExpression(parent) && parent.property === node) // not a key of Property
+  && !(t$1.isOptionalMemberExpression(parent) && parent.property === node && !parent.computed) // not a key of Property
   && !(t$1.isObjectProperty(parent) && parent.key === node) // not a property of a MemberExpression
   && !(t$1.isMemberExpression(parent) && parent.property === node && !parent.computed) // not in an Array destructure pattern
   && !t$1.isArrayPattern(parent) // not in an Object destructure pattern

--- a/src/plugins/utils/shouldPrependVM.js
+++ b/src/plugins/utils/shouldPrependVM.js
@@ -32,7 +32,7 @@ export function shouldPrependVm(path) {
     // not a param of a function
     && !(t.isFunctionExpression(parent) && parent.params.indexOf(node) > -1)
     // not a property of OptionalMemberExpression
-    && !(t.isOptionalMemberExpression(parent) && parent.property === node)
+    && !(t.isOptionalMemberExpression(parent) && parent.property === node && !parent.computed)
     // not a key of Property
     && !(t.isObjectProperty(parent) && parent.key === node)
     // not a property of a MemberExpression


### PR DESCRIPTION
This case should be consistent with the MemberExpression case, where Identifiers in **computed** OptionalMemberExpression Property should be prepended with "vm".